### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -1,5 +1,9 @@
 name: AI Code Review with OpenAI
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]


### PR DESCRIPTION
Potential fix for [https://github.com/AleksandrFurmenkovOfficial/ChatWithAI/security/code-scanning/2](https://github.com/AleksandrFurmenkovOfficial/ChatWithAI/security/code-scanning/2)

To address the issue flagged by CodeQL, we will add a `permissions` block to the root of the workflow file. This block will explicitly grant limited access permissions to the job. Based on the workflow's functionality (using repository data for code review), the minimal required permissions are likely `contents: read` and possibly `pull-requests: write`. This ensures that the job has only the necessary privileges to perform its tasks and adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
